### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/bytedeco/procamcalib/CleanBeanNode.java
+++ b/src/main/java/org/bytedeco/procamcalib/CleanBeanNode.java
@@ -35,6 +35,8 @@ import org.openide.nodes.PropertySupport;
  * @author Samuel Audet
  */
 public class CleanBeanNode<T> extends BeanNode<T> {
+    boolean renameable = true;
+
     public CleanBeanNode(T o,
             final HashMap<String, Class<? extends PropertyEditor>> editors,
             String displayName) throws IntrospectionException {
@@ -71,8 +73,6 @@ public class CleanBeanNode<T> extends BeanNode<T> {
             renameable = false;
         }
     }
-
-    boolean renameable = true;
 
     @Override public boolean canCopy() {
         return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes technical debt of 270 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
