### PR TITLE
squid:S1168 - Empty arrays and collections should be returned instead of null

### DIFF
--- a/src/main/java/org/bytedeco/procamcalib/CleanBeanNode.java
+++ b/src/main/java/org/bytedeco/procamcalib/CleanBeanNode.java
@@ -81,7 +81,7 @@ public class CleanBeanNode<T> extends BeanNode<T> {
         return renameable;
     }
     @Override public Action[] getActions(boolean context) {
-        return null;
+        return new Action[] {};
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1168 - Empty arrays and collections should be returned instead of null.
This pull request removes 30 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1168
Please let me know if you have any questions.
George Kankava
